### PR TITLE
PHP 8.4 Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,17 +46,26 @@ jobs:
           - laravel: 10.*
             php: 8.3
             testbench: 8.*
+          - laravel: 10.*
+            php: 8.4
+            testbench: 8.*
           - laravel: 11.*
             php: 8.2
             testbench: 9.*
           - laravel: 11.*
             php: 8.3
+            testbench: 9.*
+          - laravel: 11.*
+            php: 8.4
             testbench: 9.*
           - laravel: 12.*
             php: 8.2
             testbench: 10.*
           - laravel: 12.*
             php: 8.3
+            testbench: 10.*
+          - laravel: 12.*
+            php: 8.4
             testbench: 10.*
         exclude:
           - laravel: 10.*


### PR DESCRIPTION
Updates our test workflow to ensure we are covering PHP 8.4 support for Laravel 10, 11 and 12