### PR TITLE
Set minimum PHP version to 8.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,28 +9,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 11.*, 12.* ]
-        dependency-version: [ prefer-stable ]
-        include:
-          - laravel: 11.*
-            php: 8.2
-            testbench: 9.*
-          - laravel: 11.*
-            php: 8.3
-            testbench: 9.*
-          - laravel: 11.*
-            php: 8.4
-            testbench: 9.*
-          - laravel: 12.*
-            php: 8.2
-            testbench: 10.*
-          - laravel: 12.*
-            php: 8.3
-            testbench: 10.*
-          - laravel: 12.*
-            php: 8.4
-            testbench: 10.*
+         php: [ 8.4 ]
+         laravel: [ 11.*, 12.* ]
+         dependency-version: [ prefer-stable ]
+         include:
+           - laravel: 11.*
+             php: 8.4
+             testbench: 9.*
+           - laravel: 12.*
+             php: 8.4
+             testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By installing StageFront with composer, adding the middleware and setting 3 vari
 
 ## ✅ Requirements
 
--   PHP ^8.2
+-   PHP ^8.4
 -   [Laravel](https://laravel.com/) >= 11
 
 ## 📦 Installation

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "codezero/dotenv-updater": "^1.1|^2.0",
         "illuminate/support": "^11.0|^12.0"
     },


### PR DESCRIPTION
## Summary
- Remove PHP 8.2 and 8.3 support from the package
- Set minimum PHP version requirement to 8.4 in composer.json
- Update GitHub Actions test matrix to only test PHP 8.4
- Update README requirements to reflect the new minimum PHP version