### PR TITLE
Add PHP 8.5 test coverage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,15 +9,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-         php: [ 8.4 ]
+         php: [ 8.4, 8.5 ]
          laravel: [ 11.*, 12.* ]
          dependency-version: [ prefer-stable ]
          include:
            - laravel: 11.*
              php: 8.4
              testbench: 9.*
+           - laravel: 11.*
+             php: 8.5
+             testbench: 9.*
            - laravel: 12.*
              php: 8.4
+             testbench: 10.*
+           - laravel: 12.*
+             php: 8.5
              testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the test matrix in GitHub Actions
- Test PHP 8.5 with both Laravel 11.x and 12.x
- Ensure compatibility with the latest PHP version