### PR TITLE
Add support for Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
          php: [ 8.4, 8.5 ]
-         laravel: [ 11.*, 12.* ]
+         laravel: [ 11.*, 12.*, 13.* ]
          dependency-version: [ prefer-stable ]
          include:
            - laravel: 11.*
@@ -25,6 +25,12 @@ jobs:
            - laravel: 12.*
              php: 8.5
              testbench: 10.*
+           - laravel: 13.*
+             php: 8.4
+             testbench: 11.*
+           - laravel: 13.*
+             php: 8.5
+             testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "require": {
         "php": "^8.4",
         "codezero/dotenv-updater": "^1.1|^2.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.0|^11.5.3"
     },
     "scripts": {


### PR DESCRIPTION
## Summary
- Add `^13.0` constraint for `illuminate/support` in `composer.json`
- Add `^11.0` constraint for `orchestra/testbench` in `composer.json`
- Add Laravel 13 to the test matrix with `testbench 11.*` in `.github/workflows/run-tests.yml`