### PR TITLE
Remove Laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,9 @@ jobs:
       fail-fast: true
       matrix:
          php: [ 8.4, 8.5 ]
-         laravel: [ 11.*, 12.*, 13.* ]
+         laravel: [ 12.*, 13.* ]
          dependency-version: [ prefer-stable ]
          include:
-           - laravel: 11.*
-             php: 8.4
-             testbench: 9.*
-           - laravel: 11.*
-             php: 8.5
-             testbench: 9.*
            - laravel: 12.*
              php: 8.4
              testbench: 10.*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel StageFront
 
 [![GitHub release](https://img.shields.io/github/release/jamesking56/laravel-stagefront.svg?style=flat-square)](https://github.com/jamesking56/laravel-stagefront/releases)
-[![Laravel](https://img.shields.io/badge/laravel-11-red?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
+[![Laravel](https://img.shields.io/badge/laravel-12-red?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
 [![License](https://img.shields.io/packagist/l/jamesking56/laravel-stagefront.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/jamesking56/laravel-stagefront/run-tests.yml?style=flat-square&logo=github&logoColor=white&label=tests)](https://github.com/jamesking56/laravel-stagefront/actions)
 [![Code Quality](https://img.shields.io/codacy/grade/a5db8a1321664e67900c96eadc575ece/master?style=flat-square)](https://app.codacy.com/gh/jamesking56/laravel-stagefront)
@@ -22,7 +22,7 @@ By installing StageFront with composer, adding the middleware and setting 3 vari
 ## ✅ Requirements
 
 -   PHP ^8.4
--   [Laravel](https://laravel.com/) >= 11
+-   [Laravel](https://laravel.com/) >= 12
 
 ## 📦 Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "require": {
         "php": "^8.4",
         "codezero/dotenv-updater": "^1.1|^2.0",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^10.0|^11.5.3"
     },
     "scripts": {


### PR DESCRIPTION
## Summary
- Remove Laravel 11 from `illuminate/support` dependencies in `composer.json`
- Remove Laravel 11 test matrix entries from CI workflow
- Remove `orchestra/testbench` 9.x from dev dependencies
- Update README badge and requirements to reflect Laravel 12+ support

This package now requires Laravel 12 or 13.